### PR TITLE
Fix Gravity in Gazebo World

### DIFF
--- a/sawyer_gazebo/worlds/sawyer.world
+++ b/sawyer_gazebo/worlds/sawyer.world
@@ -11,10 +11,11 @@
 
     <physics type="ode">
       <real_time_update_rate>1000.0</real_time_update_rate>
-      <gravity>
-	0.0 0.0 -9.81
-      </gravity>
     </physics>
+    
+    <gravity>
+      0.0 0.0 -9.81
+    </gravity>
 
     <gui fullscreen='0'>
       <camera name='user_camera'>


### PR DESCRIPTION
The world SDF format has changed for Gazebo7, and `gravity` is now a top level attribute: 
http://sdformat.org/spec?ver=1.6&elem=world#world_gravity 
Original submitted in `baxter_simulator`:
https://github.com/RethinkRobotics/baxter_simulator/pull/113