### PR TITLE
Add & load robot_config and version params

### DIFF
--- a/sawyer_gazebo/config/params.yaml
+++ b/sawyer_gazebo/config/params.yaml
@@ -1,0 +1,21 @@
+robot_config:
+    assembly_names: [head, right, torso]
+    camera_config:
+        head_camera: {cameraType: ienso_ethernet, power: torso_camera_power}
+        right_hand_camera: {cameraType: cognex, power: right_hand_camera_power}
+    head_config:
+        joint_names: [head_pan]
+        type: head
+    right_config:
+        accelerometer_names: [right_accelerometer]
+        end_effector_names: [right_gripper]
+        joint_names: [right_j0, right_j1, right_j2, right_j3, right_j4, right_j5, right_j6]
+        type: limb
+    torso_config:
+        joint_names: [torso_t0]
+        type: torso
+manifest:
+    robot_class: sawyer
+    robot_software:
+        version:
+            HLR_VERSION_STRING: 5.2.0.0

--- a/sawyer_gazebo/launch/sawyer_world.launch
+++ b/sawyer_gazebo/launch/sawyer_world.launch
@@ -29,8 +29,8 @@
     <arg name="headless" value="$(arg headless)"/>
   </include>
 
-  <!-- Load the software version into the ROS Parameter Server -->
-  <param name="manifest/robot_software/version/HLR_VERSION_STRING" value="5.2.0" />
+  <!-- Load Parameters to the ROS Parameter Server -->
+  <rosparam command="load" file="$(find sawyer_gazebo)/config/params.yaml" />
 
   <!-- Publish a static transform between the world and the base of the robot -->
   <node pkg="tf2_ros" type="static_transform_publisher" name="base_to_world" args="0 0 0 0 0 0 1 world base" />


### PR DESCRIPTION
This adds all of the basic ROS parameters check by the SDK:

[intera_interface/robot_params.py](https://github.com/RethinkRobotics/intera_sdk/blob/development/intera_interface/src/intera_interface/robot_params.py)
[intera_interface/robot_enable.py](https://github.com/RethinkRobotics/intera_sdk/blob/development/intera_interface/src/intera_interface/robot_enable.py)

For internal tracking, resolves [IN-2024](https://jira.rethink.cxm:8443/browse/IN-2024)