### PR TITLE
Added named-poses yaml for Limb Neutral

### DIFF
--- a/sawyer_gazebo/launch/sawyer_world.launch
+++ b/sawyer_gazebo/launch/sawyer_world.launch
@@ -30,6 +30,7 @@
   </include>
 
   <!-- Load Parameters to the ROS Parameter Server -->
+  <rosparam command="load" file="$(find sawyer_description)/params/named_poses.yaml" />
   <rosparam command="load" file="$(find sawyer_gazebo)/config/params.yaml" />
 
   <!-- Publish a static transform between the world and the base of the robot -->


### PR DESCRIPTION
The `intera_interface.Limb().move_to_neutral()` function requires parameters from the param server to be set. This pulls them in from `sawyer_description` and loads them to the param server on launch.