### PR TITLE
Adds Simulated Electric Parallel Gripper

### DIFF
--- a/sawyer_gazebo/launch/sawyer_world.launch
+++ b/sawyer_gazebo/launch/sawyer_world.launch
@@ -27,7 +27,11 @@
   <rosparam command="load" file="$(find sawyer_description)/params/named_poses.yaml" />
   <rosparam command="load" file="$(find sawyer_gazebo)/config/acceleration_limits.yaml" />
   <param name="robot/limb/right/root_name" value="base" />
-  <param name="robot/limb/right/tip_name" value="right_hand" />
+  <param if="$(arg electric_gripper)" name="robot/limb/right/tip_name"
+         value="right_gripper_tip" />
+  <param unless="$(arg electric_gripper)" name="robot/limb/right/tip_name"
+         value="right_hand" />
+
   <param name="robot/limb/right/camera_name" value="right_hand_camera" />
   <param if="$(arg electric_gripper)"     name="robot/limb/right/gravity_tip_name"
          value="right_gripper_tip" />

--- a/sawyer_sim_controllers/CMakeLists.txt
+++ b/sawyer_sim_controllers/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(${PROJECT_NAME}
   src/sawyer_velocity_controller.cpp
   src/sawyer_effort_controller.cpp
   src/sawyer_gravity_controller.cpp
+  src/electric_gripper_controller.cpp
   ## Copies of upstream ros_controllers/effort_controllers:
   #  (remove once inheritable change is upstreamed)
   src/sawyer_joint_position_controller.cpp

--- a/sawyer_sim_controllers/config/electric_gripper_controller.yaml
+++ b/sawyer_sim_controllers/config/electric_gripper_controller.yaml
@@ -1,0 +1,16 @@
+robot:
+  # SDK Controllers: Gripper --------------------------
+  electric_gripper_controller:
+    type: sawyer_sim_controllers/ElectricGripperController
+    topic_command: /io/end_effector/right_gripper/command
+    topic_config:  /io/end_effector/right_gripper/config
+    topic_state:   /io/end_effector/right_gripper/state
+    joints:
+          # main joint
+          right_gripper_l_finger_controller:
+            joint: right_gripper_l_finger_joint
+            pid: {p: 5000,  i: 50, d: 0.5}
+          # mimic joint
+          right_gripper_r_finger_controller:
+            joint: right_gripper_r_finger_joint
+            pid: {p: 5000,  i: 50, d: 0.5}

--- a/sawyer_sim_controllers/config/sawyer_sim_controllers_plugins.xml
+++ b/sawyer_sim_controllers/config/sawyer_sim_controllers_plugins.xml
@@ -1,5 +1,21 @@
 <library path="lib/libsawyer_sim_controllers">
 
+    <class name="sawyer_sim_controllers/SawyerHeadController"
+	 type="sawyer_sim_controllers::SawyerHeadController"
+	 base_class_type="controller_interface::ControllerBase">
+        <description>
+           The SawyerHeadController tracks position commands for the Sawyer head pan. It expects a SharedJointInterface (EffortJointInterface) type of hardware interface.
+        </description>
+    </class>
+
+    <class name="sawyer_sim_controllers/ElectricGripperController"
+	 type="sawyer_sim_controllers::ElectricGripperController"
+	 base_class_type="controller_interface::ControllerBase">
+        <description>
+           The ElectricGripperController tracks position commands for the electric grippers. It expects a SharedJointInterface (EffortJointInterface) type of hardware interface.
+        </description>
+    </class>
+
     <class name="sawyer_sim_controllers/SawyerPositionController"
            type="sawyer_sim_controllers::SawyerPositionController"
            base_class_type="controller_interface::ControllerBase">
@@ -58,13 +74,5 @@
             The JointEffortController tracks effort commands. It expects a SharedJointInterface (EffortJointInterface) type of hardware interface.
         </description>
     </class>
-
-    <class name="sawyer_sim_controllers/SawyerHeadController"
-	 type="sawyer_sim_controllers::SawyerHeadController"
-	 base_class_type="controller_interface::ControllerBase">
-        <description>
-           The SawyerHeadController tracks position commands for the Sawyer head pan. It expects a EffortJointInterface type of hardware interface.
-        </description>
-  </class>
 
 </library>

--- a/sawyer_sim_controllers/include/sawyer_sim_controllers/electric_gripper_controller.h
+++ b/sawyer_sim_controllers/include/sawyer_sim_controllers/electric_gripper_controller.h
@@ -1,0 +1,155 @@
+/*********************************************************************
+ * Copyright (c) 2014, Kei Okada
+ * Copyright (c) 2017, Rethink Robotics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **************************************************************************/
+
+#ifndef ELECTRIC_GRIPPER_CONTROLLER_H_
+#define ELECTRIC_GRIPPER_CONTROLLER_H_
+
+#include <mutex>
+#include <ros/node_handle.h>
+#include <urdf/model.h>
+#include <controller_interface/controller.h>
+#include <realtime_tools/realtime_box.h>
+#include <intera_core_msgs/IOComponentCommand.h>
+#include <intera_core_msgs/IONodeConfiguration.h>
+#include <sawyer_sim_controllers/sawyer_joint_position_controller.h>  // used for controlling individual joints
+
+namespace sawyer_sim_controllers
+{
+  class ElectricGripperController : public controller_interface::Controller<sawyer_hardware_interface::SharedJointInterface>
+  {
+
+  public:
+    ElectricGripperController();
+    virtual ~ElectricGripperController();
+
+    bool init(sawyer_hardware_interface::SharedJointInterface* robot, ros::NodeHandle &n) ;
+    void starting(const ros::Time& time){} ;
+    void stopping(const ros::Time& time){} ;
+    void update(const ros::Time& time, const ros::Duration& period) ;
+
+  private:
+
+    ros::NodeHandle nh_;
+
+    // Last Gripper Command Position
+    realtime_tools::RealtimeBox< std::shared_ptr<double> > gripper_command_buffer_;
+
+    // Indices for mimic and orignal joints
+    int mimic_idx_;
+    int main_idx_;
+
+    size_t n_joints_;
+    double start_position_;
+    double last_position_;
+    // An indicator to evalute to true when an unproccessed new command is in the realtime buffer
+    bool new_command_;
+    size_t update_counter_;
+    intera_core_msgs::IONodeConfiguration config_;
+
+    // Command subscriber
+    ros::Subscriber gripper_command_sub_;
+    // State publisher
+    ros::Publisher gripper_state_pub_;
+    // Config publisher
+    ros::Publisher gripper_config_pub_;
+    // Higher level end effector config publisher
+    ros::Publisher end_effector_config_pub_;
+    // Timer to update publishers
+    ros::Timer pub_timer_;
+
+   /**
+    * @brief Regular update for publishing config and state
+    * @param event ROS Timer event triggered
+    */
+    void timerUpdate(const ros::TimerEvent& event);
+
+   /**
+    * @brief Retrieves new command and updates both fingers controllers
+    */
+    void updateCommands();
+
+   /**
+    * @brief Construct and publish gripper state based on internal gripper state
+    */
+    void publishState();
+
+   /**
+    * @brief Construct and publish gripper config
+    */
+    void publishConfig();
+
+    /**
+     * @brief Callback from a recieved IO Component command,
+     *        storing the new desired internal gripper state
+     * @param msg trajectory goal
+     */
+    void commandCB(const intera_core_msgs::IOComponentCommandConstPtr& msg);
+
+    // Create an effort-based joint position controller for every joint
+    std::vector<
+      std::shared_ptr<
+        sawyer_effort_controllers::JointPositionController> > gripper_controllers_;
+
+    // Class to keep track of command times
+    class TimesList{
+    public:
+        TimesList(size_t max_size){
+          max_size_ = max_size;
+        };
+        bool contains(ros::Time time){
+          return std::find(times_.begin(), times_.end(), time) != times_.end();
+        };
+        void addTime(ros::Time time){
+          times_.push_front(time);
+          if(times_.size() > max_size_){
+            times_.resize(max_size_);
+          }
+        };
+        std::vector<ros::Time> getVector(){
+          std::vector<ros::Time> v{ std::begin(times_), std::end(times_) };
+          return v;
+        };
+    private:
+        size_t max_size_;
+        std::list<ros::Time> times_;
+    } cmd_times_list_;
+
+    // Structure to maintain the internal state of gripper signals
+    struct GripperSignals{
+      bool should_publish;
+      std::mutex mutex;
+      bool calibrate;
+      bool cmd_grip;
+      double dead_zone_m;
+      double force_response_n;
+      bool go;
+      bool has_error;
+      bool is_calibrated;
+      bool is_gripping;
+      bool is_moving;
+      double position_m;
+      double position_response_m;
+      bool reboot;
+      double right_gripper_tip_object_kg;
+      double speed_mps;
+    } gripper_signals_;
+
+  };
+
+} // namespace
+
+#endif /* ELECTRIC_GRIPPER_CONTROLLER_H_ */

--- a/sawyer_sim_controllers/launch/sawyer_sim_controllers.launch
+++ b/sawyer_sim_controllers/launch/sawyer_sim_controllers.launch
@@ -8,17 +8,26 @@
   <!-- Load joint controller configurations from YAML file to parameter server -->
   <rosparam file="$(find sawyer_sim_controllers)/config/sawyer_sim_controllers.yaml" command="load"/>
 
-  <!-- load the default controllers -->
+  <!-- load the default "ON" controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="controller_manager" respawn="false"
-        output="screen" ns="/robot" args="spawn joint_state_controller" />
-
-  <!-- load the stopped controllers -->
-  <node name="controller_spawner_stopped" pkg="controller_manager" type="controller_manager" respawn="false"
-       output="screen" ns="/robot" args="load right_joint_position_controller
-                                         right_joint_velocity_controller
-                                         right_joint_effort_controller
+        output="screen" ns="/robot" args="spawn
+                                         joint_state_controller
+                                         head_position_controller
                                          right_joint_gravity_controller
-                                         head_position_controller"/>
+                                         right_joint_position_controller" />
+
+  <!-- load the default "OFF" controllers -->
+  <node name="controller_spawner_stopped" pkg="controller_manager" type="controller_manager" respawn="false"
+       output="screen" ns="/robot" args="load
+                                         right_joint_velocity_controller
+                                         right_joint_effort_controller"/>
+
+  <!-- load the Electric Gripper controllers if args set -->
+  <rosparam if="$(arg electric_gripper)" command="load"
+      file="$(find sawyer_sim_controllers)/config/electric_gripper_controller.yaml"/>
+  <node if="$(arg electric_gripper)" name="electric_gripper_controller_spawner_stopped"
+        pkg="controller_manager" type="controller_manager" respawn="false" output="screen"
+        ns="/robot" args="spawn electric_gripper_controller"/>
 
   <!-- convert joint states to TF transforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"

--- a/sawyer_sim_controllers/src/electric_gripper_controller.cpp
+++ b/sawyer_sim_controllers/src/electric_gripper_controller.cpp
@@ -1,0 +1,439 @@
+/***************************************************************************
+* Copyright (c) 2014, Kei Okada
+* Copyright (c) 2017, Rethink Robotics Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**************************************************************************/
+
+#include <sawyer_sim_controllers/electric_gripper_controller.h>
+#include <intera_core_msgs/IODeviceStatus.h>
+#include <intera_core_msgs/IODeviceConfiguration.h>
+#include <intera_core_msgs/IODataStatus.h>
+#include <intera_core_msgs/IOStatus.h>
+#include <std_msgs/String.h>
+#include <pluginlib/class_list_macros.h>
+#include <yaml-cpp/yaml.h>
+
+namespace sawyer_sim_controllers {
+
+ElectricGripperController::ElectricGripperController()
+    : new_command_(true),
+      update_counter_(0),
+      mimic_idx_(0),
+      main_idx_(0),
+      start_position_(0),
+      last_position_(start_position_),
+      cmd_times_list_(100){
+}
+
+ElectricGripperController::~ElectricGripperController() {
+    gripper_command_sub_.shutdown();
+}
+
+bool ElectricGripperController::init(sawyer_hardware_interface::SharedJointInterface* robot,
+                                ros::NodeHandle &nh) {
+
+  // Store nodehandle
+  nh_ = nh;
+
+  // Get joint sub-controllers
+  XmlRpc::XmlRpcValue xml_struct;
+  if (!nh_.getParam("joints", xml_struct)) {
+    ROS_ERROR("No 'joints' parameter in controller (namespace '%s')",
+              nh_.getNamespace().c_str());
+    return false;
+  }
+
+  // Make sure it's a struct
+  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
+    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')",
+              nh_.getNamespace().c_str());
+    return false;
+  }
+
+  // Get number of joints
+  n_joints_ = xml_struct.size();
+  ROS_ASSERT_MSG(n_joints_ == 2, "Electric Gripper expects exactly 2 joints and %zu found. Exiting.", n_joints_);
+  ROS_INFO_STREAM(
+      "Initializing ElectricGripperController with "<<n_joints_<<" joints.");
+
+  gripper_controllers_.resize(n_joints_);
+  int i = 0;  // track the joint id
+  // Iterate over both joints, and store off the main joint and mimic indeces.
+  // We're expecting to find one main joint and one mimic joint.
+  // Gazebo ROS interfaces do not currently support mimic joints, so we will
+  // take care of them manually.
+  for (const auto joint_it : xml_struct) {
+    // Get joint controller
+    if (joint_it.second.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
+      ROS_ERROR(
+          "The 'joints/joint_controller' parameter is not a struct (namespace '%s')",
+          nh_.getNamespace().c_str());
+      return false;
+    }
+    // Get joint controller name
+    std::string joint_controller_name = joint_it.first;
+    // Get the joint-namespace nodehandle
+    {
+      ros::NodeHandle joint_nh(nh_, "joints/" + joint_controller_name);
+      ROS_INFO_STREAM_NAMED(
+          "init",
+          "Loading sub-controller '" << joint_controller_name << "', Namespace: " << joint_nh.getNamespace());
+
+      gripper_controllers_[i].reset(
+          new sawyer_effort_controllers::JointPositionController());
+      gripper_controllers_[i]->init(robot, joint_nh);
+
+    }  // end of joint-namespaces
+    // Set mimic indices
+    if ( gripper_controllers_[i]->joint_urdf_->mimic ) {
+      mimic_idx_ = i;
+    }
+    else{
+      main_idx_ = i;
+    }
+    // increment joint i
+    ++i;
+  }
+  gripper_command_buffer_.set(std::make_shared<double>(start_position_));
+  std::string command_topic_name;
+  // Get controller topic name that it will subscribe to
+  if (nh_.getParam("topic_command", command_topic_name)) { // They provided a custom topic to subscribe to
+
+    // Get a node handle that is relative to the base path
+    ros::NodeHandle nh_base("~");
+
+    // Create command subscriber custom to sawyer
+    gripper_command_sub_ = nh_base.subscribe<intera_core_msgs::IOComponentCommand>(
+        command_topic_name, 1, &ElectricGripperController::commandCB, this);
+  } else  // default "command" topic
+  {
+    // Create command subscriber custom to intera
+    gripper_command_sub_ = nh_.subscribe<intera_core_msgs::IOComponentCommand>(
+        "command", 1, &ElectricGripperController::commandCB, this);
+  }
+  std::string state_topic_name;
+  if (nh_.getParam("topic_state", state_topic_name))
+  {// They provided a custom topic to subscribe to
+    // Get a node handle that is relative to the base path
+    ros::NodeHandle nh_base("~");
+    // Create command subscriber custom to sawyer
+    gripper_state_pub_ = nh_base.advertise<intera_core_msgs::IODeviceStatus>(state_topic_name, 1, true);
+  }
+  else
+  {
+    gripper_state_pub_ = nh.advertise<intera_core_msgs::IODeviceStatus>("state", 1, true);
+  }
+
+  end_effector_config_pub_ = nh.advertise<intera_core_msgs::IONodeConfiguration>("/io/end_effector/config", 1, true);
+  std::string config_topic_name;
+  if (nh_.getParam("topic_config", config_topic_name))
+  {// They provided a custom topic to subscribe to
+    // Get a node handle that is relative to the base path
+    ros::NodeHandle nh_base("~");
+    // Create command subscriber custom to sawyer
+    gripper_config_pub_ = nh_base.advertise<intera_core_msgs::IODeviceConfiguration>(config_topic_name, 1, true);
+  }
+  else
+  {
+    gripper_config_pub_ = nh.advertise<intera_core_msgs::IODeviceConfiguration>("config", 1, true);
+  }
+
+  // Populate End Effector Config
+  config_.time = ros::Time::now();
+  config_.node.name = "EndEffector";
+  auto device = intera_core_msgs::IOComponentConfiguration();
+  device.name = "right_gripper";
+  config_.devices.push_back(device);
+
+  // Set gripper signals defaults
+  {
+    std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+    gripper_signals_.calibrate=false;
+    gripper_signals_.cmd_grip=false;
+    gripper_signals_.dead_zone_m=0.002;
+    gripper_signals_.force_response_n=-2.0;
+    gripper_signals_.go=true;
+    gripper_signals_.has_error=false;
+    gripper_signals_.is_calibrated=true;
+    gripper_signals_.is_gripping=false;
+    gripper_signals_.is_moving=false;
+    gripper_signals_.position_m=start_position_;
+    gripper_signals_.position_response_m=start_position_;
+    gripper_signals_.reboot=false;
+    gripper_signals_.right_gripper_tip_object_kg=0.0;
+    gripper_signals_.speed_mps=1.5;
+    gripper_signals_.should_publish=true;
+  }
+  // Update at 5Hz
+  pub_timer_ = nh.createTimer(ros::Duration(0.2), &ElectricGripperController::timerUpdate, this);
+  publishConfig();
+  return true;
+}
+
+void ElectricGripperController::timerUpdate(const ros::TimerEvent& event) {
+    // Publish at 5Hz
+    end_effector_config_pub_.publish(config_);
+    double current_position = std::abs(gripper_controllers_[main_idx_]->getPosition())+
+                         std::abs(gripper_controllers_[mimic_idx_]->getPosition());
+    bool should_publish = false;
+    {
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      if(std::abs(current_position - last_position_) > gripper_signals_.dead_zone_m)
+      {
+        gripper_signals_.position_response_m = current_position;
+        gripper_signals_.should_publish = true;
+        last_position_ = current_position;
+      }
+      should_publish = gripper_signals_.should_publish;
+    }
+    if(should_publish){
+      publishState();
+    }
+}
+
+void ElectricGripperController::publishState() {
+    auto gripper_state = intera_core_msgs::IODeviceStatus();
+
+    gripper_state.time = ros::Time::now();
+    if(gripper_state.time.sec == 0){
+        gripper_state.time.sec = 1; // Hack to make the config valid when starting
+    }
+    gripper_state.device.name = "right_gripper";
+    auto ready_status = intera_core_msgs::IOStatus();
+    ready_status.tag = ready_status.READY;
+    ready_status.detail = "{}";
+
+    auto calibrate = intera_core_msgs::IODataStatus();
+    calibrate.name = "calibrate";
+    calibrate.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    calibrate.status = ready_status;
+
+    auto cmd_grip = intera_core_msgs::IODataStatus();
+    cmd_grip.name = "cmd_grip";
+    cmd_grip.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    cmd_grip.status = ready_status;
+
+    auto dead_zone_m = intera_core_msgs::IODataStatus();
+    dead_zone_m.name = "dead_zone_m";
+    dead_zone_m.format = "{\"role\":\"output\",\"type\":\"float\",\"units\":\"meters\"}";
+    dead_zone_m.status = ready_status;
+
+    auto force_response_n = intera_core_msgs::IODataStatus();
+    force_response_n.name = "force_response_n";
+    force_response_n.format = "{\"role\":\"input\",\"type\":\"float\"}";
+    force_response_n.status = ready_status;
+
+    auto go = intera_core_msgs::IODataStatus();
+    go.name = "go";
+    go.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    go.status = ready_status;
+
+    auto has_error = intera_core_msgs::IODataStatus();
+    has_error.name = "has_error";
+    has_error.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    has_error.status = ready_status;
+
+    auto is_calibrated = intera_core_msgs::IODataStatus();
+    is_calibrated.name = "is_calibrated";
+    is_calibrated.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    is_calibrated.status = ready_status;
+
+    auto is_gripping = intera_core_msgs::IODataStatus();
+    is_gripping.name = "is_gripping";
+    is_gripping.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    is_gripping.status = ready_status;
+
+    auto is_moving = intera_core_msgs::IODataStatus();
+    is_moving.name = "is_moving";
+    is_moving.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    is_moving.status = ready_status;
+
+    auto position_m = intera_core_msgs::IODataStatus();
+    position_m.name = "position_m";
+    position_m.format = "{\"role\":\"output\",\"type\":\"float\",\"units\":\"meters\"}";
+    position_m.status = ready_status;
+
+    auto position_response_m = intera_core_msgs::IODataStatus();
+    position_response_m.name = "position_response_m";
+    position_response_m.format = "{\"role\":\"output\",\"type\":\"float\",\"units\":\"meters\"}";
+    position_response_m.status = ready_status;
+
+    auto reboot = intera_core_msgs::IODataStatus();
+    reboot.name = "reboot";
+    reboot.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    reboot.status = ready_status;
+
+    auto right_gripper_tip_object_kg = intera_core_msgs::IODataStatus();
+    right_gripper_tip_object_kg.name = "right_gripper_tip_object_kg";
+    right_gripper_tip_object_kg.format = "{\"role\":\"output\",\"type\":\"bool\"}";
+    right_gripper_tip_object_kg.status = ready_status;
+
+    auto speed_mps = intera_core_msgs::IODataStatus();
+    speed_mps.name = "speed_mps";
+    speed_mps.format = "{\"role\":\"output\",\"type\":\"float\",\"units\":\"metersPerSecond\"}";
+    speed_mps.status = ready_status;
+
+    {
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      gripper_signals_.should_publish = false;
+      cmd_grip.data = "[" + std::string(gripper_signals_.cmd_grip ? "true" : "false") + "]";
+      dead_zone_m.data = "[" + std::to_string(gripper_signals_.dead_zone_m) + "]";
+      force_response_n.data = "[" + std::to_string(gripper_signals_.force_response_n) + "]";
+      go.data = "[" + std::string(gripper_signals_.go ? "true" : "false")  + "]";
+      is_calibrated.data = "[" + std::string(gripper_signals_.is_calibrated ? "true" : "false")  + "]";
+      is_gripping.data = "[" + std::string(gripper_signals_.is_gripping ? "true" : "false")  + "]";
+      is_moving.data = "[" + std::string(gripper_signals_.is_moving ? "true" : "false")  + "]";
+      has_error.data = "[" + std::string(gripper_signals_.has_error ? "true" : "false")  + "]";
+      position_m.data = "[" + std::to_string(gripper_signals_.position_m) + "]";
+      position_response_m.data = "[" + std::to_string(gripper_signals_.position_response_m) + "]";
+      right_gripper_tip_object_kg.data = "[" + std::to_string(gripper_signals_.right_gripper_tip_object_kg) + "]";
+      speed_mps.data = "[" + std::to_string(gripper_signals_.speed_mps) + "]";
+      // Reset cyclic data
+      reboot.data = "[" + std::string(gripper_signals_.reboot ? "true" : "false")  + "]";
+      if(gripper_signals_.reboot){
+        gripper_signals_.reboot = false;
+        gripper_signals_.is_calibrated = false;
+        gripper_signals_.should_publish = true;
+      }
+      calibrate.data = "[" + std::string(gripper_signals_.calibrate ? "true" : "false") + "]";
+      if(gripper_signals_.calibrate){
+        gripper_signals_.calibrate = false;
+        gripper_signals_.is_calibrated = true;
+        gripper_signals_.should_publish = true;
+      }
+    }
+    gripper_state.signals= {calibrate, cmd_grip, dead_zone_m, force_response_n,
+                            go, has_error, is_calibrated, is_gripping,
+                            is_moving, position_m, position_response_m, reboot,
+                            right_gripper_tip_object_kg, speed_mps};
+    gripper_state.commands = cmd_times_list_.getVector();
+    gripper_state.responses = std::vector<std::string>(gripper_state.commands.size());
+    gripper_state_pub_.publish(gripper_state);
+}
+
+void ElectricGripperController::publishConfig(){
+    auto gripper_config = intera_core_msgs::IODeviceConfiguration();
+    gripper_config.time = ros::Time::now();
+    if(gripper_config.time.sec == 0){
+        gripper_config.time.sec = 1; // Hack to make the config valid when starting
+    }
+    gripper_config.device.name = "right_gripper";
+    gripper_config.device.config = "{}";
+    gripper_config_pub_.publish(gripper_config);
+}
+
+void ElectricGripperController::update(const ros::Time& time, const ros::Duration& period)
+{
+  update_counter_++;
+  //TODO: Change to ROS Param (20 Hz)
+  if (update_counter_ % 5 == 0) {
+    updateCommands();
+  }
+  // Apply joint commands
+  for (size_t i = 0; i < n_joints_; i++) {
+    // Update the individual joint controllers
+    gripper_controllers_[i]->update(time, period);
+  }
+}
+
+void ElectricGripperController::updateCommands() {
+  // Check if we have a new command to publish
+  if (!new_command_)
+    return;
+  // Go ahead and assume we have proccessed the current message
+  new_command_ = false;
+  // Get latest command
+  std::shared_ptr<double> cmd;
+  gripper_command_buffer_.get(cmd);
+  if(cmd.get()){
+    auto cmd_position = *(cmd.get());
+    // Update the individual joint controllers
+    ROS_DEBUG_STREAM(gripper_controllers_[main_idx_]->joint_urdf_->name <<
+                     "->setCommand(" << cmd_position << ")");
+    gripper_controllers_[main_idx_]->setCommand(cmd_position,
+        gripper_signals_.speed_mps);
+    gripper_controllers_[mimic_idx_]->setCommand(
+        gripper_controllers_[mimic_idx_]->joint_urdf_->mimic->multiplier*
+        cmd_position+gripper_controllers_[mimic_idx_]->joint_urdf_->mimic->offset,
+        gripper_signals_.speed_mps);
+  }
+}
+
+void ElectricGripperController::commandCB(
+    const intera_core_msgs::IOComponentCommandConstPtr& msg) {
+  // Save off Command Time if new
+  if(!cmd_times_list_.contains(msg->time)){
+    cmd_times_list_.addTime(msg->time);
+    // Publish Current State
+    ROS_DEBUG_STREAM("Gripper update commands " << msg->args);
+    YAML::Node args = YAML::Load(msg->args);
+    if(args["signals"]["position_m"])
+    {
+      auto cmd_position = std::min(std::max(args["signals"]["position_m"]["data"][0].as<double>()/2.0,
+                                          gripper_controllers_[main_idx_]->joint_urdf_->limits->lower),
+                                          gripper_controllers_[main_idx_]->joint_urdf_->limits->upper);
+      {
+        std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+        gripper_signals_.position_m = cmd_position*2.0;
+        gripper_signals_.should_publish=true;
+      }
+      gripper_command_buffer_.set(std::make_shared<double>(cmd_position));
+      new_command_ = true;
+    }
+    if(args["signals"]["speed_mps"])
+    {
+      auto cmd_velocity = std::min(std::max(args["signals"]["speed_mps"]["data"][0].as<double>(),
+                                            -gripper_controllers_[main_idx_]->joint_urdf_->limits->velocity),
+                                            gripper_controllers_[main_idx_]->joint_urdf_->limits->velocity);
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      gripper_signals_.speed_mps=cmd_velocity;
+      gripper_signals_.should_publish=true;
+    }
+    if(args["signals"]["dead_zone_m"])
+    {
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      gripper_signals_.dead_zone_m=args["signals"]["dead_zone_m"]["data"][0].as<double>();
+      gripper_signals_.should_publish=true;
+    }
+    if(args["signals"]["go"])
+    {
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      gripper_signals_.go=args["signals"]["go"]["data"][0].as<bool>();
+      gripper_signals_.should_publish=true;
+    }
+    if(args["signals"]["calibrate"])
+    {
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      gripper_signals_.calibrate=args["signals"]["calibrate"]["data"][0].as<bool>();
+      gripper_signals_.should_publish=true;
+    }
+    if(args["signals"]["reboot"])
+    {
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      gripper_signals_.reboot=args["signals"]["reboot"]["data"][0].as<bool>();
+      gripper_signals_.should_publish=true;
+    }
+    if(args["signals"]["right_gripper_tip_object_kg"])
+    {
+      std::lock_guard<std::mutex> lock(gripper_signals_.mutex);
+      gripper_signals_.right_gripper_tip_object_kg=args["signals"]["right_gripper_tip_object_kg"]["data"][0].as<double>();
+      gripper_signals_.should_publish=true;
+    }
+  }
+}
+
+}  // namespace
+
+PLUGINLIB_EXPORT_CLASS(sawyer_sim_controllers::ElectricGripperController,
+                       controller_interface::ControllerBase)


### PR DESCRIPTION
This PR adds the Electric Parallel Gripper (EPG) support to Sawyer Gazebo. The changes consist of

- Adds launchfile `args` necessary for `electric_gripper`. Invoke with
  `$ roslaunch sawyer_gazebo sawyer_world.launch electric_gripper:=true`
- Adds a (moderately tuned) `ros_controls` PID controller yaml for the electric gripper 
- Changes the way `ros_controls` controllers are loaded. Some are now `spawn`ed to start
  them by default. These include: `joint_state_controller,  head_position_controller,
  right_joint_gravity_controller,  right_joint_position_controller` and the
  `electric_gripper_controller` when it is specified
- Finally, adds a class `ros_controllers` class to accept IO Framework gripper commands
  (the same way it is done with the real robot), and respond with IO Framework style responses