### PR TITLE
Adds disabling of Gravity Compensation Torques

### DIFF
--- a/sawyer_sim_controllers/config/sawyer_sim_controllers.yaml
+++ b/sawyer_sim_controllers/config/sawyer_sim_controllers.yaml
@@ -100,7 +100,9 @@ robot:
   # Sawyer SDK Controllers: Gravity Compensation ------------
   right_joint_gravity_controller:
     type: sawyer_sim_controllers/SawyerGravityController
-    topic: /robot/limb/right/gravity_compensation_torques
+    command_topic: /robot/limb/right/gravity_compensation_torques
+    disable_topic: /robot/limb/right/suppress_gravity_compensation
+    disable_timeout: 0.2
     joints:
       right_j0_controller:
         joint: right_j0

--- a/sawyer_sim_controllers/include/sawyer_sim_controllers/sawyer_gravity_controller.h
+++ b/sawyer_sim_controllers/include/sawyer_sim_controllers/sawyer_gravity_controller.h
@@ -19,8 +19,11 @@
 
 #include <sawyer_sim_controllers/joint_array_controller.h>
 #include <intera_core_msgs/SEAJointState.h>
+#include <std_msgs/Empty.h>
+#include <realtime_tools/realtime_box.h>
 #include <sawyer_sim_controllers/sawyer_joint_effort_controller.h>
 #include <ros/node_handle.h>
+#include <ros/time.h>
 
 #include <control_toolbox/pid.h>
 
@@ -37,8 +40,12 @@ namespace sawyer_sim_controllers
 
   private:
     ros::Subscriber sub_joint_command_;
+    ros::Subscriber sub_gravity_disable_;
+    realtime_tools::RealtimeBox< std::shared_ptr<const ros::Time > > box_disable_time_;
+    ros::Duration gravity_disable_timeout_;
 
     void gravityCommandCB(const intera_core_msgs::SEAJointStateConstPtr& msg);
+    void gravityDisableCB(const std_msgs::Empty& msg);
   };
 }
 


### PR DESCRIPTION
This creates a newly subscribed topic:
`/robot/limb/right/suppress_gravity_compensation`
which takes a `std_msgs/Empty` message. If this topic
is published to at >= 5.0 Hz, all gravity compensation
torque additions are disabled.

The user can publish directly from the commandline:
`$ rostopic pub /robot/limb/right/suppress_gravity_compensation
std_msgs/Empty "{}" -r 5`

This leads to poorer tracking in Position, Trajectory,
and Velocity modes as each mode's PID controller is tuned
for gravity torques to be present, and has to work harder
to hold up the arm.
In Torque control mode, this causes the arm to drop down
completely unless the user is providing torques to counter
gravity.