### PR TITLE
Adds JointCommand Timeout to Position Control

### DIFF
--- a/sawyer_gazebo/include/sawyer_gazebo/arm_controller_interface.h
+++ b/sawyer_gazebo/include/sawyer_gazebo/arm_controller_interface.h
@@ -22,6 +22,7 @@
 #include <controller_manager/controller_manager.h>
 
 #include <std_msgs/Float64.h>
+#include <realtime_tools/realtime_box.h>
 #include <intera_core_msgs/JointCommand.h>
 
 
@@ -37,6 +38,12 @@ namespace sawyer_gazebo {
     std::mutex mtx_;
     int current_mode_;
     std::string side_;
+
+    realtime_tools::RealtimeBox< std::shared_ptr<const ros::Duration > > box_timeout_length_;
+    realtime_tools::RealtimeBox< std::shared_ptr<const ros::Time > > box_cmd_timeout_;
+
+    ros::Timer cmd_timeout_timer_;
+
     ros::Subscriber joint_command_timeout_sub_;
     ros::Subscriber joint_command_sub_;
     boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
@@ -45,6 +52,8 @@ namespace sawyer_gazebo {
     void jointCommandTimeoutCallback(const std_msgs::Float64 msg);
     void jointCommandCallback(const intera_core_msgs::JointCommandConstPtr& msg);
     std::string getControllerString(std::string mode_str);
+    bool switchControllers(int control_mode);
+    void commandTimeoutCheck(const ros::TimerEvent& e);
 
 
   };

--- a/sawyer_gazebo/src/arm_controller_interface.cpp
+++ b/sawyer_gazebo/src/arm_controller_interface.cpp
@@ -24,14 +24,43 @@ void ArmControllerInterface::init(ros::NodeHandle& nh, std::string side,
   current_mode_ = -1;
   side_ = side;
   controller_manager_ = controller_manager;
-  joint_command_timeout_sub_ = nh.subscribe("limb/"+side_+"/joint_command_timeout", 1,
-                       &ArmControllerInterface::jointCommandTimeoutCallback, this);
   joint_command_sub_ = nh.subscribe("limb/"+side_+"/joint_command", 1,
                        &ArmControllerInterface::jointCommandCallback, this);
+
+  // Command Timeout
+  joint_command_timeout_sub_ = nh.subscribe("limb/"+side_+"/joint_command_timeout", 1,
+                       &ArmControllerInterface::jointCommandTimeoutCallback, this);
+  double command_timeout_default;
+  nh.param<double>("command_timeout", command_timeout_default, 0.2);
+  auto p_cmd_timeout_length = std::make_shared<ros::Duration>(std::min(1.0,
+                                std::max(0.0, command_timeout_default)));
+  box_timeout_length_.set(p_cmd_timeout_length);
+
+  // Update at 100Hz
+  cmd_timeout_timer_ = nh.createTimer(100, &ArmControllerInterface::commandTimeoutCheck, this);
+}
+
+void ArmControllerInterface::commandTimeoutCheck(const ros::TimerEvent& e) {
+  // lock out other thread(s) which are getting called back via ros.
+  std::lock_guard<std::mutex> guard(mtx_);
+  // Check Command Timeout
+  std::shared_ptr<const ros::Duration>  p_timeout_length;
+  box_timeout_length_.get(p_timeout_length);
+  std::shared_ptr<const ros::Time>  p_cmd_msg_time;
+  box_cmd_timeout_.get(p_cmd_msg_time);
+  bool command_timeout = (p_cmd_msg_time && p_timeout_length &&
+      ((ros::Time::now() - *p_cmd_msg_time.get()) > (*p_timeout_length.get())));
+  if(command_timeout) {
+    // Timeout violated, force robot back to Position Mode
+    switchControllers(intera_core_msgs::JointCommand::POSITION_MODE);
+  }
 }
 
 void ArmControllerInterface::jointCommandTimeoutCallback(const std_msgs::Float64 msg) {
-  ROS_INFO_STREAM_NAMED("sawyer_control_plugin", "Joint command timeout: " << msg.data);
+  ROS_DEBUG_STREAM_THROTTLE_NAMED(1, "sawyer_control_plugin", "Joint command timeout: " << msg.data);
+  auto p_cmd_timeout_length = std::make_shared<ros::Duration>(
+                                std::min(1.0, std::max(0.0, double(msg.data))));
+  box_timeout_length_.set(p_cmd_timeout_length);
 }
 
 std::string ArmControllerInterface::getControllerString(std::string mode_str){
@@ -40,15 +69,13 @@ std::string ArmControllerInterface::getControllerString(std::string mode_str){
     return ss.str();
 }
 
-void ArmControllerInterface::jointCommandCallback(const intera_core_msgs::JointCommandConstPtr& msg) {
-  // lock out other thread(s) which are getting called back via ros.
-  std::lock_guard<std::mutex> guard(mtx_);
-
+bool ArmControllerInterface::switchControllers(int control_mode) {
   std::vector<std::string> start_controllers;
   std::vector<std::string> stop_controllers;
-  if(current_mode_ != msg->mode)
+  // mod3 to account for equivalence between position (1) and trajectory (4) controllers
+  if(current_mode_%3 != control_mode%3)
   {
-    switch (msg->mode)
+    switch (control_mode)
     {
       case intera_core_msgs::JointCommand::POSITION_MODE:
       case intera_core_msgs::JointCommand::TRAJECTORY_MODE:
@@ -70,24 +97,31 @@ void ArmControllerInterface::jointCommandCallback(const intera_core_msgs::JointC
         stop_controllers.push_back(getControllerString("velocity"));
         break;
       default:
-        ROS_ERROR_STREAM_NAMED("ros_control_plugin", "Unknown command mode " << msg->mode);
-        return;
+        ROS_ERROR_STREAM_NAMED("ros_control_plugin", "Unknown JointCommand mode "
+                                << control_mode << ". Ignoring command.");
+        return false;
     }
     if (!controller_manager_->switchController(start_controllers, stop_controllers,
                               controller_manager_msgs::SwitchController::Request::BEST_EFFORT))
     {
       ROS_ERROR_STREAM_NAMED("ros_control_plugin", "Failed to switch controllers");
+      return false;
     }
-    else
-    {
-      current_mode_ = msg->mode;
-      //is_disabled = false;
-      //ROS_INFO_NAMED("ros_control_plugin", "Robot is enabled");
-      ROS_INFO_STREAM_NAMED("ros_control_plugin", "Controller " << start_controllers[0]
-                            << " started and " << stop_controllers[0] + " and " + stop_controllers[1] << " stopped.");
-      //ROS_INFO_NAMED("ros_control_plugin", "Gravity compensation was turned on by mode command callback");
-    }
+    current_mode_ = control_mode;
+    ROS_INFO_STREAM_NAMED("ros_control_plugin", "Controller " << start_controllers[0]
+                            << " started and " << stop_controllers[0] +
+                            " and " + stop_controllers[1] << " stopped.");
   }
-
+  return true;
 }
+
+void ArmControllerInterface::jointCommandCallback(const intera_core_msgs::JointCommandConstPtr& msg) {
+  // lock out other thread(s) which are getting called back via ros.
+  std::lock_guard<std::mutex> guard(mtx_);
+  if(switchControllers(msg->mode)) {
+    auto p_cmd_msg_time = std::make_shared<ros::Time>(ros::Time::now());
+    box_cmd_timeout_.set(p_cmd_msg_time);
+  }
+}
+
 }


### PR DESCRIPTION
Adds command timeout. This is implemented on the real robot, preventing the robot from continuously moving if JointCommand is published too infrequently. If the minimum frequency is met, the controllers will function as normal. If the timeout is violated, the arm switches to Position Control mode and holds its position.

This PR:
- Switches controllers back to Position Control (from Torque or Velocity control modes) if command timeout is violated
- Adds a subscriber to configure how long to wait for JointCommand Timeouts

Note: This approach does *not* not stop the arm from moving if the arm is already in Position/Trajectory mode. Additional investigation is required to force these modes to stop movement and hold position if the timeout is violated.