### PR TITLE
Sim Controller Tuning

### DIFF
--- a/sawyer_sim_controllers/config/sawyer_sim_controllers.yaml
+++ b/sawyer_sim_controllers/config/sawyer_sim_controllers.yaml
@@ -3,7 +3,7 @@ robot:
 
   joint_state_controller:
     type: joint_state_controller/JointStateController
-    publish_rate: 50
+    publish_rate: 100
 
   # Sawyer SDK Controllers: Head --------------------------
   head_position_controller:
@@ -23,25 +23,25 @@ robot:
     joints:
       right_j0_controller:
         joint: right_j0
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 500,  i: 0.01, d: 10}
       right_j1_controller:
         joint: right_j1
         pid: {p: 700,  i: 0.01, d: 100}
       right_j2_controller:
         joint: right_j2
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 500,  i: 0.01, d: 50}
       right_j3_controller:
         joint: right_j3
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 500,  i: 0.01, d: 50}
       right_j4_controller:
         joint: right_j4
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 600,  i: 1.0, d: 100}
       right_j5_controller:
         joint: right_j5
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 1500,  i: 0.01, d: 120}
       right_j6_controller:
         joint: right_j6
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 50,  i: 10, d: 10}
 
   # Sawyer SDK Controllers: Velocity --------------------------
   right_joint_velocity_controller:
@@ -50,25 +50,25 @@ robot:
     joints:
       right_j0_controller:
         joint: right_j0
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 10,  i: 0.0, d: 0.1}
       right_j1_controller:
         joint: right_j1
-        pid: {p: 100,  i: 100, d: 100}
+        pid: {p: 100,  i: 1.0, d: 0.1}
       right_j2_controller:
         joint: right_j2
-        pid: {p: 100,  i: 100, d: 100}
+        pid: {p: 0.05,  i: 0.0, d: 0.01}
       right_j3_controller:
         joint: right_j3
-        pid: {p: 100,  i: 100, d: 100}
+        pid: {p: 0.5,  i: 0.01, d: 0.1}
       right_j4_controller:
         joint: right_j4
-        pid: {p: 100,  i: 100, d: 100}
+        pid: {p: 1.0,  i: 0.0, d: 0.01}
       right_j5_controller:
         joint: right_j5
-        pid: {p: 100,  i: 100, d: 100}
+        pid: {p: 0.05,  i: 0.0, d: 0.01}
       right_j6_controller:
         joint: right_j6
-        pid: {p: 100,  i: 100, d: 100}
+        pid: {p: 0.05,  i: 0.0, d: 0.01}
 
   # Sawyer SDK Controllers: Effort --------------------------
   right_joint_effort_controller:


### PR DESCRIPTION
Corresponds with https://github.com/RethinkRobotics/sawyer_robot/pull/47

Now that all the controllers have been created, and the software processes are in place to emulate the real Sawyer robot's API's, this is the latest round of tuning for Sawyer's `Position`(&`Trajectory`) and `Velocity` Controllers. This corresponds with some URDF tweaks in order to make Gazebo happy: increased zero mass & inertia links to have a minimum mass and inertia, and re-tuned joint damping and friction for simulation.

This was tested with a computer capable of running Sawyer in Gazebo at a consistent Real Time Factor of 1.0 throughout the duration of testing.
- `Trajectory Mode` works well(-ish) with MoveIt! Nearly all trajectories execute without violating the real Sawyer's joint tracking or Goal Velocity constraints
- Regular `Position Mode` moves at nearly the same speed as the real Sawyer
- `Velocity Mode` works well with the joint_velocity_wobbler.py example script

The one slight downside is that with the retuning, and mass/inertia tweaks, Gravity Compensation is just barely not enough to hold up the arm when commanding only Zero Torques. Funny enough, this is actually closer to the reality of the real Sawyer.