### PR TITLE
Fixes for Gravity Compensation Torque Calculation

### DIFF
--- a/sawyer_gazebo/include/sawyer_gazebo/arm_kinematics_interface.h
+++ b/sawyer_gazebo/include/sawyer_gazebo/arm_kinematics_interface.h
@@ -27,6 +27,8 @@
 #include <intera_core_msgs/JointLimits.h>
 #include <intera_core_msgs/SolvePositionFK.h>
 #include <intera_core_msgs/SolvePositionIK.h>
+#include <intera_core_msgs/SEAJointState.h>
+
 #include <geometry_msgs/Twist.h>
 
 #include <kdl/chainidsolver_recursive_newton_euler.hpp>
@@ -154,12 +156,13 @@ bool computePositionIK(const Kinematics& kin, const geometry_msgs::Pose& cart_po
  */
 bool computeVelocityFK(const Kinematics& kin, const KDL::JntArrayVel& jnt_vel, geometry_msgs::Twist& result);
 
-/* Method to calculate the gravity torques FK for the required joint positions in rad and
+/* Method to calculate the gravity+coriolis+inertia torques for the required joint positions in rad and
  * joint velocities in rad/sec with the result stored in the provided KDL JointArray
  * @returns true if successful
  */
-bool computeGravityFK(const Kinematics& kin, const KDL::JntArray& jnt_pos,
-                      const KDL::JntArray& jnt_vel, KDL::JntArray& jnt_torques);
+bool computeGravity(const Kinematics& kin, const KDL::JntArray& jnt_pos,
+                    const KDL::JntArray& jnt_vel, const KDL::JntArray& jnt_accel,
+                    KDL::JntArray& jnt_torques);
 
 /* Method to break down a JointState message object into the corresponding
  * KDL position, velocity, and effort Joint Arrays
@@ -176,6 +179,13 @@ void jointStatePositionToKDL(const sensor_msgs::JointState& joint_configuration,
   KDL::JntArray jnt_vel, jnt_eff;
   jointStateToKDL(joint_configuration, kin, jnt_pos, jnt_vel, jnt_eff);
 };
+
+/* Method to break down a JointCommand message object into the corresponding
+ * the SEAJointState message (aka gravity_compensation_torques)
+ */
+void jointCommandToGravityMsg(const std::vector<std::string>& joint_names,
+                              const intera_core_msgs::JointCommand& command_msg,
+                              intera_core_msgs::SEAJointState& gravity_msg);
 
 };
 }  // namespace sawyer_gazebo

--- a/sawyer_gazebo/launch/sawyer_world.launch
+++ b/sawyer_gazebo/launch/sawyer_world.launch
@@ -9,8 +9,24 @@
   <arg name="debug" default="false"/>
   <arg name="head_display_img" default="$(find sawyer_gazebo)/share/images/sawyer_sdk_research.png"/>
 
-  <!-- These arguments load the electric grippers, for example electric_gripper:=true -->
+  <!-- This argument loads the electric gripper, for example electric_gripper:=true -->
   <arg name="electric_gripper" default="false"/>
+  <!-- This argument loads sawyer's pedestal URDF -->
+  <arg name="pedestal" default="true"/>
+  <!-- This argument fixes the robot statically to the world -->
+  <arg name="static" default="true"/>
+  <!-- This argument dictates whether gazebo should be launched in this file -->
+  <arg name="load_gazebo" default="true"/>
+  <!-- This argument sets the initial joint states -->
+  <arg name="initial_joint_states"
+    default=" -J sawyer::right_j0 -0.27
+              -J sawyer::right_j1 1.05
+              -J sawyer::right_j2 0.00
+              -J sawyer::right_j3 0.49
+              -J sawyer::right_j4 -0.08
+              -J sawyer::right_j5 -0.06
+              -J sawyer::right_j6 0.027
+              -J sawyer::head_pan 0.00"/>
 
   <param name="img_path_head_display" value="$(arg head_display_img)"/>
 
@@ -21,7 +37,8 @@
   <arg name="load_robot_description" default="true"/>
   <param if="$(arg load_robot_description)" name="robot_description"
       command="$(find xacro)/xacro --inorder $(find sawyer_description)/urdf/sawyer.urdf.xacro
-      gazebo:=true electric_gripper:=$(arg electric_gripper)"/>
+      gazebo:=true electric_gripper:=$(arg electric_gripper)
+      pedestal:=$(arg pedestal) static:=$(arg static)"/>
   <!-- Load Parameters to the ROS Parameter Server -->
   <rosparam command="load" file="$(find sawyer_gazebo)/config/config.yaml" />
   <rosparam command="load" file="$(find sawyer_description)/params/named_poses.yaml" />
@@ -40,7 +57,7 @@
 
 
   <!-- We resume the logic in empty_world.launch, changing the name of the world to be launched -->
-  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+  <include if="$(arg load_gazebo)" file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find sawyer_gazebo)/worlds/sawyer.world"/>
     <arg name="debug" value="$(arg debug)" />
     <arg name="gui" value="$(arg gui)" />
@@ -50,18 +67,12 @@
   </include>
 
   <!-- Publish a static transform between the world and the base of the robot -->
-  <node pkg="tf2_ros" type="static_transform_publisher" name="base_to_world" args="0 0 0 0 0 0 1 world base" />
+  <node if="$(arg static)" pkg="tf2_ros" type="static_transform_publisher"
+	name="base_to_world" args="0 0 0 0 0 0 1 world base" />
 
   <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
    <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
-	args="-param robot_description -urdf -z 0.93 -model sawyer
-              -J sawyer::right_j0 -0.272659
-              -J sawyer::right_j1 1.04701
-              -J sawyer::right_j2 -0.00123203
-              -J sawyer::right_j3 0.49262
-              -J sawyer::right_j4 -0.0806423
-              -J sawyer::right_j5 -0.0620532
-              -J sawyer::right_j6 0.0265941" />
+	args="-param robot_description -urdf -z 0.93 -model sawyer $(arg initial_joint_states)" />
 
   <!-- ros_control sawyer launch file -->
   <include file="$(find sawyer_sim_controllers)/launch/sawyer_sim_controllers.launch">

--- a/sawyer_sim_controllers/config/sawyer_sim_controllers.yaml
+++ b/sawyer_sim_controllers/config/sawyer_sim_controllers.yaml
@@ -23,25 +23,25 @@ robot:
     joints:
       right_j0_controller:
         joint: right_j0
-        pid: {p: 500,  i: 0.01, d: 10}
+        pid: {p: 500.0,  i: 10.0, d: 25.0}
       right_j1_controller:
         joint: right_j1
-        pid: {p: 700,  i: 0.01, d: 100}
+        pid: {p: 400.0,  i: 10.0, d: 30.0}
       right_j2_controller:
         joint: right_j2
-        pid: {p: 500,  i: 0.01, d: 50}
+        pid: {p: 250.0,  i: 10.0, d: 30.0}
       right_j3_controller:
         joint: right_j3
-        pid: {p: 500,  i: 0.01, d: 50}
+        pid: {p: 300.0,  i: 10.0, d: 50.0}
       right_j4_controller:
         joint: right_j4
-        pid: {p: 600,  i: 1.0, d: 100}
+        pid: {p: 300.0,  i: 10.0, d: 8.0}
       right_j5_controller:
         joint: right_j5
-        pid: {p: 1500,  i: 0.01, d: 120}
+        pid: {p: 100.0,  i: 1.0, d: 5.0}
       right_j6_controller:
         joint: right_j6
-        pid: {p: 50,  i: 10, d: 10}
+        pid: {p: 50.0,  i: 10.0, d: 4.0}
 
   # Sawyer SDK Controllers: Velocity --------------------------
   right_joint_velocity_controller:
@@ -77,25 +77,18 @@ robot:
     joints:
       right_j0_controller:
         joint: right_j0
-        pid: {p: 700,  i: 0.01, d: 100}
       right_j1_controller:
         joint: right_j1
-        pid: {p: 100,  i: 100, d: 100}
       right_j2_controller:
         joint: right_j2
-        pid: {p: 100,  i: 100, d: 100}
       right_j3_controller:
         joint: right_j3
-        pid: {p: 100,  i: 100, d: 100}
       right_j4_controller:
         joint: right_j4
-        pid: {p: 100,  i: 100, d: 100}
       right_j5_controller:
         joint: right_j5
-        pid: {p: 100,  i: 100, d: 100}
       right_j6_controller:
         joint: right_j6
-        pid: {p: 100,  i: 100, d: 100}
 
   # Sawyer SDK Controllers: Gravity Compensation ------------
   right_joint_gravity_controller:
@@ -106,22 +99,15 @@ robot:
     joints:
       right_j0_controller:
         joint: right_j0
-        pid: {p: 700,  i: 0.01, d: 100}
       right_j1_controller:
         joint: right_j1
-        pid: {p: 100,  i: 100, d: 100}
       right_j2_controller:
         joint: right_j2
-        pid: {p: 100,  i: 100, d: 100}
       right_j3_controller:
         joint: right_j3
-        pid: {p: 100,  i: 100, d: 100}
       right_j4_controller:
         joint: right_j4
-        pid: {p: 100,  i: 100, d: 100}
       right_j5_controller:
         joint: right_j5
-        pid: {p: 100,  i: 100, d: 100}
       right_j6_controller:
         joint: right_j6
-        pid: {p: 100,  i: 100, d: 100}

--- a/sawyer_sim_controllers/src/sawyer_gravity_controller.cpp
+++ b/sawyer_sim_controllers/src/sawyer_gravity_controller.cpp
@@ -55,7 +55,7 @@ namespace sawyer_sim_controllers {
   void SawyerGravityController::gravityCommandCB(const intera_core_msgs::SEAJointStateConstPtr& msg) {
 
       std::vector<Command> commands;
-      if (msg->name.size() != msg->gravity_only.size()) {
+      if (msg->name.size() != msg->gravity_model_effort.size()) {
         ROS_ERROR_STREAM_NAMED(JOINT_ARRAY_CONTROLLER_NAME, "Gravity commands size does not match joints size");
       }
       std::shared_ptr<const ros::Time>  p_disable_msg_time;
@@ -64,7 +64,7 @@ namespace sawyer_sim_controllers {
       for (int i = 0; i < msg->name.size(); i++) {
         Command cmd = Command();
         cmd.name_ = msg->name[i];
-        cmd.effort_ = enable_gravity ? msg->gravity_only[i] : 0.0;
+        cmd.effort_ = enable_gravity ? msg->gravity_model_effort[i] : 0.0;
         commands.push_back(cmd);
       }
       command_buffer_.writeFromNonRT(commands);


### PR DESCRIPTION
 ###  Fixed Gravity Compensation Torque Calculation
    
  - Adds compensation for Coreolis Torques (from actual velocity)
  - Adds compensation for Inertial Torques (from commanded acceleration)
  - Fixed bug with Zero-initialization of `KDL JointArrays`, which
    would cause jitter in the simulated arm
  - Use full `gravity_model_effort` which composes Gravity,
    Coreolis, and Inertial Torques instead of just `gravity_only`
  - Removed unused PID values for torque and gravity controllers
  - Retuned Position PID controller



 ### Adds new params for sawyer_world launch
    
  - Adds `pedestal` param to launch to allow removing pedestal
  - Adds `static` param to allow the robot base to move in Gazebo
  - Adds `initial_joint_states` param, but it's not (currently) functional
  - Adds `load_gazebo` param, to allow for gazebo to be launched separate
