### PR TITLE
Include joint_state_controller dependency

### DIFF
--- a/sawyer_sim_controllers/package.xml
+++ b/sawyer_sim_controllers/package.xml
@@ -27,6 +27,7 @@
   <build_depend>intera_core_msgs</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>sawyer_hardware_interface</build_depend>
+  <build_depend>joint_state_controller</build_depend>
 
   <run_depend>effort_controllers</run_depend>
   <run_depend>roscpp</run_depend>
@@ -34,6 +35,7 @@
   <run_depend>intera_core_msgs</run_depend>
   <run_depend>controller_interface</run_depend>
   <run_depend>sawyer_hardware_interface</run_depend>
+  <run_depend>joint_state_controller</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Currently the joint_state_controller package is not a dependency, so it is not installed using rosdep. Include joint_state_controller in sawyer_sim_controllers/package.xml. 