### PR TITLE
doc: updating links to new locations on the website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ sawyer_simulator
 
 Gazebo simulation with emulated interfaces for the Sawyer Research Robot. Please follow the tutorial_ on the Rethink Robotics Wiki to get started with Sawyer in Gazebo.
 
-.. _tutorial: http://sdk.rethinkrobotics.com/intera/Gazebo_Tutorial
+.. _tutorial: https://support.rethinkrobotics.com/support/solutions/articles/80000980381-gazebo-tutorial
 
 .. image:: sawyer_gazebo/etc/sawyer_gazebo.gif
 
@@ -11,7 +11,7 @@ Code & Tickets
 --------------
 
 +-----------------+----------------------------------------------------------------------------------+
-| Documentation   | http://sdk.rethinkrobotics.com/intera                                            |
+| Documentation   | https://support.rethinkrobotics.com/support/home                                 |
 +-----------------+----------------------------------------------------------------------------------+
 | Issues          | https://github.com/RethinkRobotics/sawyer_simulator/issues                       |
 +-----------------+----------------------------------------------------------------------------------+
@@ -52,4 +52,4 @@ Other Sawyer Repositories
 Latest Release Information
 --------------------------
 
-http://sdk.rethinkrobotics.com/intera/Release-Changes
+https://support.rethinkrobotics.com/support/solutions/folders/80000687452

--- a/sawyer_gazebo/package.xml
+++ b/sawyer_gazebo/package.xml
@@ -10,7 +10,7 @@
     Rethink Robotics Inc.
   </maintainer>
   <license>Apache 2.0</license>
-  <url type="website">http://sdk.rethinkrobotics.com/intera/</url>
+  <url type="website">https://support.rethinkrobotics.com/support/home</url>
   <url type="repository">
     https://github.com/RethinkRobotics/sawyer_simulator
   </url>

--- a/sawyer_hardware_interface/package.xml
+++ b/sawyer_hardware_interface/package.xml
@@ -8,7 +8,7 @@
     Rethink Robotics Inc.
   </maintainer>
   <license>Apache 2.0</license>
-  <url type="website">http://sdk.rethinkrobotics.com/intera/</url>
+  <url type="website">https://support.rethinkrobotics.com/support/home</url>
   <url type="repository">
     https://github.com/RethinkRobotics/sawyer_simulator
   </url>

--- a/sawyer_sim_controllers/package.xml
+++ b/sawyer_sim_controllers/package.xml
@@ -10,7 +10,7 @@
     Rethink Robotics Inc.
   </maintainer>
   <license>Apache 2.0</license>
-  <url type="website">http://sdk.rethinkrobotics.com/intera/</url>
+  <url type="website">https://support.rethinkrobotics.com/support/home</url>
   <url type="repository">
     https://github.com/RethinkRobotics/sawyer_simulator
   </url>

--- a/sawyer_sim_examples/package.xml
+++ b/sawyer_sim_examples/package.xml
@@ -8,7 +8,7 @@
     Rethink Robotics Inc.
   </maintainer>
   <license>Apache 2.0</license>
-  <url type="website">http://sdk.rethinkrobotics.com/intera/</url>
+  <url type="website">https://support.rethinkrobotics.com/support/home</url>
   <url type="repository">
     https://github.com/RethinkRobotics/sawyer_simulator
   </url>

--- a/sawyer_simulator/package.xml
+++ b/sawyer_simulator/package.xml
@@ -10,7 +10,7 @@
     Rethink Robotics Inc.
   </maintainer>
   <license>Apache 2.0</license>
-  <url type="website">http://sdk.rethinkrobotics.com/intera</url>
+  <url type="website">https://support.rethinkrobotics.com/support/home</url>
   <url type="repository">
     https://github.com/RethinkRobotics/sawyer_simultor
   </url>


### PR DESCRIPTION
The sdk.rethinkrobotics.com has moved to support.rethinkrobotics.com. This is a pure documentation update and fixes the locations.